### PR TITLE
Update README.md requirements: add ROCm SDKs and libstdc++ dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ rocHPL is a benchmark based on the [HPL][] benchmark application, implemented on
 * Git
 * CMake (3.10 or later)
 * MPI (Optional)
-* AMD [ROCm] platform (3.5 or later)
+* AMD [ROCm] platform (3.5 or later) with all SDK packages
 * [rocBLAS][]
+* libstdc++ development package
 
 ## Quickstart rocHPL build and install
 


### PR DESCRIPTION
- libstdc++-12-dev is needed otherwise rochpl compilation fails with: 
In file included from <built-in>:1:
In file included from /opt/rocm-6.0.2/lib/llvm/lib/clang/17.0.0/include/__clang_hip_runtime_wrapper.h:50:
/opt/rocm-6.0.2/lib/llvm/lib/clang/17.0.0/include/cuda_wrappers/cmath:27:15: fatal error: 'cmath' file not found
#include_next <cmath>
              ^~~~~~~
- Make requirements for ROCm SDKs packages explicit