### PR TITLE
Fix for non-constexpr warpSize

### DIFF
--- a/include/hpl_hip_ex.hpp
+++ b/include/hpl_hip_ex.hpp
@@ -781,7 +781,16 @@ __device__ inline void block_maxloc(double& max,
       max = s_max[t];
       loc = s_loc[t];
     }
-    wavefront_maxloc<warpSize>(max, loc);
+
+    // The compiler optimizes the branching away in the middle end
+    // so we should see no difference in performance or code size
+    // at the end of compilation
+    if(warpSize == 32) {
+       wavefront_maxloc<32>(max, loc);
+    } else {
+       wavefront_maxloc<64>(max, loc);
+    }
+
     s_max[t] = max;
     s_loc[t] = loc;
   }


### PR DESCRIPTION
Starting with ROCm 7.0, we can no longer depend on warpSize being constexpr, so we cannot use it as a template parameter. However, the compiler can still fold it in, so we write code that branches on the warpSize with the knowledge that the compiler will optimize away the branch.

Supersedes #18 and resolves #19 