### PR TITLE
Support for tencentos 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ supported_distro( )
   fi
 
   case "${ID}" in
-    debian|linuxmint|ubuntu|centos|rhel|fedora|sles)
+    debian|linuxmint|ubuntu|centos|rhel|fedora|sles|tencentos)
         true
         ;;
     *)  printf "This script is currently supported on Debian, Linuxmint, Ubuntu, CentOS, RHEL, Fedora and SLES\n"
@@ -68,7 +68,7 @@ exit_with_error( )
         printf "sudo apt install -y ${library_dependencies_ubuntu[*]}\n"
         ;;
 
-      centos|rhel)
+      centos|rhel|tencentos)
         printf "sudo yum -y --nogpgcheck install ${library_dependencies_centos[*]}\n"
         ;;
 

--- a/scripts/mpirun_rochpl.in
+++ b/scripts/mpirun_rochpl.in
@@ -46,7 +46,7 @@ supported_distro( )
   fi
 
   case "${ID}" in
-    debian|linuxmint|ubuntu|centos|rhel|fedora|sles)
+    debian|linuxmint|ubuntu|centos|rhel|fedora|sles|tencentos)
         true
         ;;
     *)  printf "This script is currently supported on Debian, Linuxmint, Ubuntu, CentOS, RHEL, Fedora and SLES\n"

--- a/scripts/run_rochpl.in
+++ b/scripts/run_rochpl.in
@@ -46,7 +46,7 @@ supported_distro( )
   fi
 
   case "${ID}" in
-    debian|linuxmint|ubuntu|centos|rhel|fedora|sles)
+    debian|linuxmint|ubuntu|centos|rhel|fedora|sles|tencentos)
         true
         ;;
     *)  printf "This script is currently supported on Debian, Linuxmint, Ubuntu, CentOS, RHEL, Fedora and SLES\n"


### PR DESCRIPTION
## Motivation

Support for tencentos (AMD internal ticket https://ontrack-internal.amd.com/browse/PLAT-186622)

## Technical Details

Currently the support is missing for tencentos.

## Test Plan

Tested with tencentos

## Test Result

Successful run on tencentos

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
