### PR TITLE
Fix CMakelists to support modern versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 option(HPL_VERBOSE_PRINT   "Enable printing to terminal during run" OFF)
 option(HPL_PROGRESS_REPORT "Enable printing progess report to terminal during run" OFF)
@@ -53,7 +53,7 @@ if(POLICY CMP0066)
 endif()
 
 # rocHPL project
-project(rochpl LANGUAGES CXX)
+project(rochpl LANGUAGES CXX HIP)
 
 # Build flags
 set(CMAKE_CXX_STANDARD 11)
@@ -79,47 +79,26 @@ list(REMOVE_ITEM rochpl_source ${rochpl_device_source})
 
 # Flag source files as hip source files
 foreach(i ${rochpl_device_source})
-  set_source_files_properties(${i} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT TRUE)
+  set_source_files_properties(${i} PROPERTIES LANGUAGE HIP)
 endforeach()
 
-# HIP flags workaround while target_compile_options does not work
-list(APPEND HIP_HIPCC_FLAGS "-Wno-unused-command-line-argument -Wno-deprecated-declarations -fPIE -fopenmp")
-list(APPEND CMAKE_HOST_FLAGS "-Wno-deprecated-declarations")
+list(APPEND ROCHPL_COMPILE_FLAGS -Wno-deprecated-declarations)
+list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-Wno-unused-command-line-argument>)
+list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-fPIE>)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  list(APPEND HIP_HIPCC_FLAGS "-g -ggdb")
-  list(APPEND CMAKE_HOST_FLAGS "-O0;-g")
+  list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-ggdb>)
 else()
-  list(APPEND HIP_HIPCC_FLAGS "-O3 -march=native -ffp-contract=fast -ffast-math -funsafe-math-optimizations")
-  list(APPEND CMAKE_HOST_FLAGS "-O3;-march=native")
+  list(APPEND ROCHPL_COMPILE_FLAGS -march=native)
+  list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-ffp-contract=fast>)
+  list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-ffast-math>)
+  list(APPEND ROCHPL_COMPILE_FLAGS $<$<COMPILE_LANGUAGE:HIP>:-funsafe-math-optimizations>)
 endif()
-
-# GPU arch targets
-set(TARGETS "gfx900;gfx906")
-if(HIP_VERSION VERSION_GREATER_EQUAL "3.7")
-  set(TARGETS "${TARGETS};gfx908")
-endif()
-if(HIP_VERSION VERSION_GREATER_EQUAL "4.3")
-  set(TARGETS "${TARGETS};gfx90a")
-endif()
-if (HIP_VERSION VERSION_GREATER_EQUAL "5.7")
-  set(TARGETS "${TARGETS};gfx942")
-endif()
-if (HIP_VERSION VERSION_GREATER_EQUAL "6.5")
-  set(TARGETS "${TARGETS};gfx950;gfx1100")
-endif()
-if (HIP_VERSION VERSION_GREATER_EQUAL "7.0")
-  set(TARGETS "${TARGETS};gfx1201")
-endif()
-
-foreach(target ${TARGETS})
-  list(APPEND HIP_HIPCC_FLAGS "--offload-arch=${target}")
-endforeach()
 
 # Target executable
-hip_add_executable(rochpl ${rochpl_source} ${rochpl_device_source})
+add_executable(rochpl ${rochpl_source} ${rochpl_device_source})
 
-target_compile_options(rochpl PRIVATE ${CMAKE_HOST_FLAGS})
+target_compile_options(rochpl PRIVATE ${ROCHPL_COMPILE_FLAGS})
 
 if(HPL_VERBOSE_PRINT)
   target_compile_definitions(rochpl PRIVATE HPL_VERBOSE_PRINT)
@@ -141,10 +120,12 @@ endif()
 target_include_directories(rochpl
                            PRIVATE
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-                           $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-                           $<BUILD_INTERFACE:${HPL_MPI_DIR}/include>
-                           $<BUILD_INTERFACE:${ROCM_PATH}/include/roctracer>)
+                           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+if(HPL_TRACING)
+  target_include_directories(rochpl
+                             PRIVATE
+                             $<BUILD_INTERFACE:${ROCM_PATH}/include/roctracer>)
+endif()
 
 #HIP
 target_link_libraries(rochpl PRIVATE hip::host)
@@ -175,8 +156,6 @@ if(MPI_GTL)
   find_library(GTL_LIB libmpi_gtl_hsa.so.0 "${MPI_GTL}")
   target_link_libraries(rochpl PRIVATE "${GTL_LIB}")
 endif()
-
-set_target_properties(rochpl PROPERTIES HIP_ARCHITECTURES "${DEFAULT_AMDGPU_TARGETS}")
 
 # Configure a header file to pass the rocHPL version
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/hpl_version.hpp.in"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ rocHPL is a benchmark based on the [HPL][] benchmark application, implemented on
 
 ## Requirements
 * Git
-* CMake (3.10 or later)
+* CMake (3.21 or later)
 * MPI (Optional)
 * AMD [ROCm] platform (3.5 or later)
 * [rocBLAS][]
@@ -27,6 +27,7 @@ cd rocHPL
 #    --with-rocm=<dir>    - Path to ROCm install (Default: /opt/rocm)
 #    --with-rocblas=<dir> - Path to rocBLAS library (Default: /opt/rocm/rocblas)
 #    --with-mpi=<dir>     - Path to external MPI install (Default: clone+build OpenMPI)
+#    --archs=<list>       - Comma separated architectures list to build (Default: Cmake default (device architectures detected on the system))"
 #    --verbose-print      - Verbose output during HPL setup (Default: true)
 #    --progress-report    - Print progress report to terminal during HPL run (Default: true)
 #    --detailed-timing    - Record detailed timers during HPL run (Default: true)

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ function display_help()
   echo "    [--with-rocblas=<dir>] Path to rocBLAS library (Default: /opt/rocm/rocblas)"
   echo "    [--with-mpi=<dir>] Path to external MPI install (Default: clone+build OpenMPI)"
   echo "    [--with-mpi-gtl=<dir>] Path to external MPI-GTL install (Optional: defaults to no gtl support)"
+  echo "    [--archs] Comma separated architecture list to build (Default: Cmake default (device architectures detected on the system))"
   echo "    [--verbose-print] Verbose output during HPL setup (Default: true)"
   echo "    [--progress-report] Print progress report to terminal during HPL run (Default: true)"
   echo "    [--detailed-timing] Record detailed timers during HPL run (Default: true)"
@@ -219,6 +220,7 @@ build_release=true
 with_rocm=/opt/rocm
 with_mpi=tpl/openmpi
 with_mpi_gtl=none
+archs=default
 with_rocblas=/opt/rocm/rocblas
 verbose_print=true
 progress_report=true
@@ -232,7 +234,7 @@ enable_tracing=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,debug,prefix:,with-rocm:,with-mpi:,with-mpi-gtl:,with-rocblas:,verbose-print:,progress-report:,detailed-timing:,enable-tracing: --options hg -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,debug,prefix:,with-rocm:,with-mpi:,with-mpi-gtl:,with-rocblas:,archs:,verbose-print:,progress-report:,detailed-timing:,enable-tracing: --options hg -- "$@")
 else
   echo "Need a new version of getopt"
   exit_with_error 1
@@ -268,6 +270,9 @@ while true; do
         shift 2 ;;
     --with-rocblas)
         with_rocblas=${2}
+        shift 2 ;;
+    --archs)
+        archs=${2}
         shift 2 ;;
     --verbose-print)
         verbose_print=${2}
@@ -325,13 +330,16 @@ pushd .
   if [[ "${with_mpi_gtl}" != none ]]; then
     cmake_common_options="${cmake_common_options} -DMPI_GTL=${with_mpi_gtl}"
   fi
-  
 
   # build type
   if [[ "${build_release}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Release"
   else
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug"
+  fi
+
+  if [[ "${archs}" != default ]]; then
+    cmake_common_options="${cmake_common_options} -DCMAKE_HIP_ARCHITECTURES=${archs}"
   fi
 
   shopt -s nocasematch


### PR DESCRIPTION
## Motivation

Since cmake 3.21 HIP is a language in cmake.
cmake 3.31.8 doesn't support `hip_add_executable` and therefore the build fails.

## Technical Details

HIP language has been enabled in the project.
device file gets the property `LANGUAGE HIP` to be compiled correctly.
compile options are now added with `target_compile_options` for both C++ and HIP (HIP workaround not needed anymore)
`CMAKE_HIP_ARCHITECTURES` is now used removing the need of manually handling the GPU architectures.

## Test Plan and Result

Several cmake builds have been done to check the results of the configuration.
`install.sh` has been tested to ensure that the `--archs` option works as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
