### PR TITLE
fix: bump UCX pin to v1.19.1 for FIFO room calculation fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,9 @@ install_openmpi( )
 
   if [ ! -d "./tpl/ucx" ]; then
     mkdir -p tpl && cd tpl
-    git clone --branch v1.18.0 https://github.com/openucx/ucx.git ucx
+    # v1.19.1 is the first release containing the UCT/MM FIFO room fix
+    # (openucx/ucx#10823, commit 6b2e361) that prevents hangs when tail > head.
+    git clone --branch v1.19.1 https://github.com/openucx/ucx.git ucx
     check_exit_code 2
     cd ucx;
     ./autogen.sh; ./autogen.sh #why do we have to run this twice?


### PR DESCRIPTION
## Summary

UCX `v1.18.0` (the current pin) has a bug in the UCT/MM shared-memory transport where the FIFO room calculation is wrong when `tail > head`, leading to hangs or data corruption under certain MPI communication patterns.

- **Upstream fix:** openucx/ucx#10823 (commit `6b2e361`, merged 2025-09-25)
- **Fix NOT in:** `v1.18.0`, `v1.18.1` (tagged 2025-04-28, before the fix)
- **Fix NOT in:** `v1.19.0` (tagged 2025-08-05, before the fix)
- **Fix first included in:** `v1.19.1` (tagged 2025-12-07) ✓

## Change

```diff
-    git clone --branch v1.18.0 https://github.com/openucx/ucx.git ucx
+    # v1.19.1 is the first release containing the UCT/MM FIFO room fix
+    # (openucx/ucx#10823, commit 6b2e361) that prevents hangs when tail > head.
+    git clone --branch v1.19.1 https://github.com/openucx/ucx.git ucx
```

No other changes — OpenMPI pin (`v5.0.7`) and all build flags are unchanged.

## Testing

A clean build with `./install.sh` should be validated on an affected configuration (shared-memory / RoCE transport) to confirm the hang no longer reproduces.